### PR TITLE
Add Reef to Projects → useful supporting infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Selected implementations and frameworks for building self-improving agents and a
 - [Harbor](https://github.com/harbor-framework/harbor) — containerized agent tasks, verifiers, evaluation, and RL rollouts.
 - [ART](https://github.com/OpenPipe/ART) — agent reinforcement learning from scored trajectories.
 - [verl](https://github.com/verl-project/verl) — distributed training for custom rollout, reward, and policy-update loops.
+- [Reef](https://github.com/Human-Agent-Society/reef) — serving endpoint that records interactions, matches later feedback to them, and publishes versioned weight or harness updates to live traffic.
 
 </details>
 


### PR DESCRIPTION
> **Disclosure:** I am a maintainer of Reef.

Adds one line to the `🧰 Useful supporting infrastructure` block inside **🛠️ Projects**, next to Harbor / ART / verl.

```markdown
- [Reef](https://github.com/Human-Agent-Society/reef) — serving endpoint that records interactions, matches later feedback to them, and publishes versioned weight or harness updates to live traffic.
```

### What the contributing section asks for

- **Resource name:** Reef
- **First public date:** 2026-08-31 (repository creation; released on PyPI as `reef-infra`)
- **Primary link:** https://github.com/Human-Agent-Society/reef
- **Code / weights / data:** code is Apache-2.0 at the link above; package `reef-infra` on PyPI; docs at https://reefinfra.ai/docs/. No released weights, no released datasets.
- **One sentence on the contribution:** Reef is the serving-side plumbing for a continual-learning loop — it fronts an agent with an OpenAI- and Anthropic-compatible endpoint (`/v1/chat/completions`, `/v1/messages`), returns a receipt for each interaction in the `x-reef-agent-record-id` response header, lets a later report attach a score and/or textual or structured feedback to those receipts, batches eligible records into a candidate update to either model weights (SAO recipe) or a harness tree of rules, skills, prompts, configuration and extensions (`harness_evolve` recipe), and serves accepted updates as versioned, rollback-capable artifacts without restarting the endpoint.

### Why the infrastructure block and not the Projects tables

The two Projects tables index systems that *are* the learning loop — an agent, a research loop, a self-play setup. Reef is not one of those and I am not proposing it as one. It is the layer underneath: the endpoint that stays up, the record/feedback join, and the artifact version history. Harbor, ART and verl are in that block for the same reason, and Reef does not overlap with any of them — none of the three serves live traffic or versions a served artifact, and Reef does not implement an RL algorithm.

The one thing Reef adds that I think is list-relevant: `harness_evolve` treats the harness as a versioned artifact behind an automated promotion gate — it evaluates current vs. candidate on the configured tasks and publishes the candidate only when it wins — rather than as static config edited by hand.

### Three things you should weigh before merging

1. **No benchmark results, no reproducible evaluation.** Reef publishes none of its own improvement claims, and I am making no performance claim here. Nothing in the proposed line asserts that anything gets better; it describes mechanism only. If your bar for the Projects section includes published evidence of improvement, Reef does not clear it today and you should close this.
2. **No paper.** There is no arXiv preprint or venue publication to cite, so there is no `Reference date` that points at a paper — the date above is a software release date.
3. **Persistent, not recursive.** Reef's improvement machinery is fixed across rounds: the updater, the feedback-matching logic and the evaluation gate are all operator-defined and are not themselves subject to the loop. If your criterion for this repository is that the improvement mechanism improves itself, the answer for Reef is no. That is exactly why I am asking for the supporting-infrastructure block and **not** for any RSI-labelled category.

### Checks run

The repository contains only `README.md` — no CONTRIBUTING file, no linter, no generator, no CI workflow — so there was nothing to run or regenerate. I did not touch any other entry, and did not refresh any star badge.

What I checked by hand:

- `git diff --stat` → `README.md | 1 +`, one insertion, zero deletions.
- Entry format matches its three neighbours in the block: `- [Name](url) — lowercase description.`
- Links in the added line and in this PR resolve: repo `200`, PyPI `200`, `https://reefinfra.ai/docs/` `308` → `200` at `https://www.reefinfra.ai/docs/getting-started/intro/`.
- No star count or badge added, consistent with the block's plain-bullet style.

Happy to reword the line, move it, or have this closed if it is outside what you want indexed — no hard feelings either way.
